### PR TITLE
Renamed 'NonSpecific...' error to 'Unspecific...' and updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ dataclass_instance = MyDataclass.from_dict(origin_dict)
 ["First", "Second", "Third"]
 ```
 
-If we were to use `typing.List` or `list` as the field type, an error would be raised when converting the dictionary (there's more info on errors later).
+If we were to use the more generic `typing.List` or `list` as the field type, an error would be raised when converting the dictionary (there's more info on errors later).
 
 ```python
 @dataclass
@@ -125,21 +125,47 @@ origin_dict = {
     "my_list_field": ["First", "Second", "Third"]
 }
 
-# Here, a `NonSpecificListFieldError` is raised
+# Here, an `UnspecificListFieldError` is raised
 dataclass_instance = MyDataclass.from_dict(origin_dict)
+```
+
+Lists of other dataclasses are also supported.
+
+```python
+@dataclass
+class Child(DataclassFromDict):
+    name: str = field_from_dict()
+
+
+@dataclass
+class Parent(DataclassFromDict):
+    children: List[Child] = field_from_dict()
+
+
+origin_dict = {
+  "children": [
+      { "name": "Jane" },
+      { "name": "Joe" },
+  ]
+}
+
+dataclass_instance = Parent.from_dict(origin_dict)
+
+>>> dataclass_instance.children
+[Child(name='Jane'), Child(name='Joe')]
 ```
 
 ## Custom value converters
 
-By default, `str`, `int`, `bool`, `float` types can be taken from dictionaries without conversion.
+By default, `str`, `int`, `bool` and `float` types can be taken from dictionaries without conversion.
 
-Dataclass fields of type `datetime` can be converted from
+Dataclass fields of type `datetime` are also handled and can be converted from
 
-- Strings (handled by `dateutil`)
+- Strings (handled by [dateutil](https://dateutil.readthedocs.io/en/stable/))
 - Python-style timestamps of type `float`, e.g. `1602436272.681808`
 - Javascript-style timestamps of type `int`, e.g. `1602436323268`
 
-If you need to convert a dictionary value that isn't covered by the defaults, you can pass in a converter function to `field_from_dict`:
+If you need to convert a dictionary value that isn't covered by the defaults, you can pass in a converter function using `field_from_dict`'s `converter` parameter:
 
 ```python
 def yes_no_to_bool(yes_no: str) -> bool:

--- a/dict_to_dataclass/__init__.py
+++ b/dict_to_dataclass/__init__.py
@@ -2,7 +2,7 @@ from dataclasses import Field, field, fields, is_dataclass, MISSING
 from dict_to_dataclass.exceptions import (
     DictKeyNotFoundError,
     DictValueConversionError,
-    NonSpecificListFieldError,
+    UnspecificListFieldError,
     DictValueNotFoundError,
 )
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
@@ -46,7 +46,7 @@ def _type_is_list_with_item_type(field_type):
     is_list = hasattr(field_type, "__origin__") and field_type.__origin__ is list
 
     if is_list and isinstance(field_type.__args__[0], TypeVar):
-        raise NonSpecificListFieldError()
+        raise UnspecificListFieldError()
 
     return is_list
 
@@ -107,7 +107,7 @@ def _convert_value_for_dataclass(value_from_dict, dc_field: Field = None, list_i
     if _type_is_list_with_item_type(field_type):
         return [_convert_value_for_dataclass(item, list_item_type=field_type.__args__[0]) for item in value_from_dict]
     elif field_type is list:
-        raise NonSpecificListFieldError()
+        raise UnspecificListFieldError()
 
     if is_dataclass(field_type):
         return dataclass_from_dict(field_type, value_from_dict)

--- a/dict_to_dataclass/exceptions.py
+++ b/dict_to_dataclass/exceptions.py
@@ -38,7 +38,7 @@ class DictValueConversionError(DataclassFromDictError):
         self.value_from_json = value_from_dict
 
 
-class NonSpecificListFieldError(DataclassFromDictError):
+class UnspecificListFieldError(DataclassFromDictError):
     """Raised when a list field in a dataclass does not specify the type of its items
 
     E.g.::

--- a/dict_to_dataclass/tests/test_dict_to_dataclass.py
+++ b/dict_to_dataclass/tests/test_dict_to_dataclass.py
@@ -9,7 +9,7 @@ from dict_to_dataclass import (
     field_from_dict,
     DictKeyNotFoundError,
     DictValueConversionError,
-    NonSpecificListFieldError,
+    UnspecificListFieldError,
     DictValueNotFoundError,
 )
 
@@ -231,8 +231,8 @@ class DictToDataclassTestCase(TestCase):
 
         origin_dict = {"testList": []}
 
-        with self.assertRaises(NonSpecificListFieldError):
+        with self.assertRaises(UnspecificListFieldError):
             dataclass_from_dict(TestClass1, origin_dict)
 
-        with self.assertRaises(NonSpecificListFieldError):
+        with self.assertRaises(UnspecificListFieldError):
             dataclass_from_dict(TestClass2, origin_dict)


### PR DESCRIPTION
Updated the README with the renamed error and added an example of converting lists of other dataclasses