### PR TITLE
Set the minimum requirement to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requirements,
     url="https://github.com/jackd68ed/dict-to-dataclass",
 )


### PR DESCRIPTION
The walrus operator was introduced in version [3.8](https://www.python.org/dev/peps/pep-0572/).

PR to bump the minimum requirement for Python up a minor version.