### PR TITLE
Update requirements.txt with python-dateutil==2.8.2 instead of 2.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil==2.8.1
+python-dateutil==2.8.2


### PR DESCRIPTION
Needs for Celery 5.3.0.

Hello, dear Developer!

We really love your library and use it on the project :+1: .

And we also like to use Celery (as everybody does :100: )

But we don't want to stuck with the dependency restrictions which Celery has as their requirements. So after upgrading to Celery 5.3.0 your lib was broken and we decided to make this Pull Request to continue using your cool library :) 

Thank you for your work and for this lib!